### PR TITLE
missing RPC metadata set to None

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,12 +18,12 @@ jobs:
   pytest:
     runs-on: ubuntu-latest
     steps:
-    # no need exept if we decide to depend on the iceye_io
-    #  - uses: webfactory/ssh-agent@v0.5.1
-    #    with:
-    #      ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - uses: actions/checkout@v2
+        with:
+          python-version: '3.8'
       - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
       - run: |
           pip install invoke
           inv setup

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,13 +3,13 @@ default_language_version:
 
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.24.0
+    rev: v2.29.1
     hooks:
       - id: pyupgrade
         args: [ --py36-plus ]
 
   - repo: https://github.com/ambv/black
-    rev: 21.7b0
+    rev: 21.12b0
     hooks:
         - id: black
           args: ['-l 88', '--diff']

--- a/icecube/bin/sar_cube/slc_datacube.py
+++ b/icecube/bin/sar_cube/slc_datacube.py
@@ -208,10 +208,13 @@ class SLCDatacube(SARDatacube):
                     meta_dict[key] = np.array_str(np.array(h5_meta_val[()]))
 
                     # RPCs are nested under "RPC/" in the h5 thus need to be parsed in a specific manner
-        RPC_source = h5f["RPC"]
+        if "RPC" in h5f:
+            RPC_source = h5f["RPC"]
 
-        for key, val in RPC_source.items():
-            meta_dict[f"RPC_{key}"] = np.array(val, dtype=np.float32)
+            for key, val in RPC_source.items():
+                meta_dict[f"RPC_{key}"] = np.array(val, dtype=np.float32)
+        else:
+            meta_dict["RPC"] = np.array(None, dtype=np.float32)
 
         return meta_dict
 

--- a/icecube/utils/analytics_IO.py
+++ b/icecube/utils/analytics_IO.py
@@ -328,10 +328,14 @@ def read_SLC_metadata(h5_io):
                 meta_dict[key] = np.array(h5_meta_val[()])
 
     # RPCs are nested under "RPC/" in the h5 thus need to be parsed in a specific manner
-    RPC_source = h5_io["RPC"]
-    meta_dict["RPC"] = parse_slc_rpc_to_meta_dict(
-        RPC_source=RPC_source, meta_dict=meta_dict
-    )
+    if "RPC" in h5_io:
+        RPC_source = h5_io["RPC"]
+        meta_dict["RPC"] = parse_slc_rpc_to_meta_dict(
+            RPC_source=RPC_source, meta_dict=meta_dict
+        )
+    else:
+        meta_dict["RPC"] = None
+        warnings.warn("RPC information is missing from the raster, setting to None")
 
     return meta_dict
 

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ ml_requirements = [
 
 setup(
     name="icecube",
-    version="1.1.0",
+    version="1.1.1",
     author="Muhammad Irfan Ali, Arnaud Dupeyrat",
     author_email="irfan.ali@iceye.com, arnaud.dupeyrat@iceye.fi",
     description="AI oriented datacube generation using ICEYE data",

--- a/tasks.py
+++ b/tasks.py
@@ -6,7 +6,7 @@ Docker specific tasks are prefixed with a d. docker run > drun
 import os
 from invoke import task
 
-PYTEST = "python3 -m pytest"
+PYTEST = "python3.8 -m pytest"
 PYTEST_COVERAGE = "-m pytest"
 PYTEST_FLAGS = "--color yes --durations 3 -ra --failed-first -x"
 


### PR DESCRIPTION
related to issue: https://github.com/iceye-ltd/icecube/issues/11
Some of old ICEYE images can have RPC information missing. If that happens `RPC` key will be missing and pipeline does not work. `RPC` is now set to None if it's missing with a user warning generated.